### PR TITLE
Log HTTP listener output, and refactor construction redirect target URL 

### DIFF
--- a/app.go
+++ b/app.go
@@ -6,11 +6,10 @@ import (
 )
 
 func handler(res http.ResponseWriter, req *http.Request) {
-	target := "https://" + req.Host + req.URL.Path
-	if len(req.URL.RawQuery) > 0 {
-		target += "?" + req.URL.RawQuery
-	}
-	http.Redirect(res, req, target, http.StatusMovedPermanently)
+	target := *req.URL
+	target.Scheme = "https"
+	target.Host = req.Host
+	http.Redirect(res, req, target.String(), http.StatusMovedPermanently)
 }
 
 func main() {

--- a/app.go
+++ b/app.go
@@ -1,6 +1,9 @@
 package main
 
-import "net/http"
+import (
+	"log"
+	"net/http"
+)
 
 func handler(res http.ResponseWriter, req *http.Request) {
 	target := "https://" + req.Host + req.URL.Path
@@ -12,5 +15,5 @@ func handler(res http.ResponseWriter, req *http.Request) {
 
 func main() {
 	http.HandleFunc("/", handler)
-	http.ListenAndServe(":80", nil)
+	log.Fatal(http.ListenAndServe(":80", nil))
 }


### PR DESCRIPTION
Just some small changes. Thoughts welcomed.

    Log output of `http.ListenAndServe(..)`

    The method may return an error, and logging its output will
    provide information about the program if for example, it fails
    to start correctly (e.g. conflicting ports).

    Refactor construction of redirect target URL

    Previously, the target URL was constructed using string concatenation
    which is not idiomatic. This commit uses Go's `url.URL` to alter
    a copy of the current URL's protocol scheme. The resulting copy is
    then used as the target URL. All other URL artifacts should be
    preserved.
